### PR TITLE
Add stream filters for won and lost deals

### DIFF
--- a/lib/triggers/deal_lost/index.js
+++ b/lib/triggers/deal_lost/index.js
@@ -65,6 +65,7 @@ exports.handle = (plg, event) => {
       per_page: 100,
       dealStatus: 3,
       since: lastReqAt,
+      lostAtGt: lastReqAt,
       sort_by_newest: true
     }
   }).then(async (res) => {

--- a/lib/triggers/deal_won/index.js
+++ b/lib/triggers/deal_won/index.js
@@ -65,6 +65,7 @@ exports.handle = (plg, event) => {
       per_page: 100,
       dealStatus: 2,
       since: lastReqAt,
+      wonAtGt: lastReqAt,
       sort_by_newest: true
     }
   }).then(async (res) => {


### PR DESCRIPTION
Como conversado com o @leocamelo, o agendor ficou de utilizar a informação de `won_at` e `lost_at` nos `deals` para que um update de um negócio ganho/perdido deixasse de ativar seu respectivo trigger, e este PR conclui essas alterações.